### PR TITLE
Add user context from email and use it in event parsing

### DIFF
--- a/functions/util/emailHandler.js
+++ b/functions/util/emailHandler.js
@@ -4,7 +4,9 @@ const {logger} = require("firebase-functions");
 const {getUserFromEmail,
   addPendingEmailAddress,
   removeEmailAddress,
-  deleteUser} = require("./firestoreHandler");
+  deleteUser,
+  getUserContext,
+  setUserContext} = require("./firestoreHandler");
 const {getOauthClient,
   deleteAccount} = require("./authHandler");
 const {processEmail} = require("./openai");
@@ -136,6 +138,8 @@ async function handleEmail(email, files) {
   // Track all received emails with the action type
   sendEvent(uid, "emailReceived", {action: subjectAction});
   switch (subjectAction) {
+    case "setContext":
+      return await setUserContextFromEmail(email, sender, uid);
     case "addUser":
       return await addEmailAddressToUser(email, sender, uid, files);
     case "removeEmail":
@@ -165,7 +169,9 @@ async function sendToSupport(sender, email) {
 
 function understandSubject(subject) {
   subject = subject.toLowerCase();
-  if (subject.startsWith("add")) {
+  if (subject.startsWith("context")) {
+    return "setContext";
+  } else if (subject.startsWith("add")) {
     return "addUser";
   } else if (subject.startsWith("remove")) {
     return "removeEmail";
@@ -276,6 +282,44 @@ async function addEmailAddressToUser(email, sender, uid, files = []) {
   await sendEmailResponse(emailAddressToAdd, email, response, false);
   sendEvent(uid, "addUserRequest");
   return {verificationCode};
+}
+
+async function setUserContextFromEmail(email, sender, uid) {
+  let oldContext = "";
+  try {
+    oldContext = await getUserContext(uid);
+  } catch (error) {
+    logger.warn(`Unable to read existing userContext for uid ${uid}:`, error);
+  }
+
+  const newContext = (email.text || "").trim();
+  await setUserContext(uid, newContext);
+
+  const formatContextForHtml = (context) => {
+    if (!context) {
+      return "(none)";
+    }
+    return context.replace(/\n/g, "<br>");
+  };
+
+  const htmlBody = `
+<p>Your context has been updated.</p>
+<p><strong>Old context:</strong><br>${formatContextForHtml(oldContext)}</p>
+<p><strong>New context:</strong><br>${formatContextForHtml(newContext)}</p>
+  `;
+
+  const threadedHtml = threadEmailHtml(email, htmlBody);
+
+  await sendEmailResend({
+    to: sender,
+    from: MAIN_EMAIL_ADDRESS,
+    subject: `Re: ${email.subject}`,
+    html: threadedHtml,
+    headers: getEmailThreadHeaders(email.headers),
+  });
+
+  sendEvent(uid, "userContextUpdated");
+  return {oldContext, newContext};
 }
 
 async function eventHandler(email, sender, uid, files = []) {

--- a/functions/util/firestoreHandler.js
+++ b/functions/util/firestoreHandler.js
@@ -170,6 +170,33 @@ async function deleteUser(uid) {
   return;
 }
 
+async function getUserContext(uid) {
+  try {
+    const userDoc = await getFirestore().collection("Users").doc(uid).get();
+    if (!userDoc.exists) {
+      throw new Error("User document does not exist");
+    }
+    const data = userDoc.data();
+    return data && data.userContext ? data.userContext : "";
+  } catch (error) {
+    logger.error(`Database error in getUserContext for uid ${uid}:`, error);
+    sendEvent(uid, "databaseError", {operation: "getUserContext"});
+    throw error;
+  }
+}
+
+async function setUserContext(uid, context) {
+  try {
+    await getFirestore().collection("Users").doc(uid).set({
+      userContext: context,
+    }, {merge: true});
+  } catch (error) {
+    logger.error(`Database error in setUserContext for uid ${uid}:`, error);
+    sendEvent(uid, "databaseError", {operation: "setUserContext"});
+    throw error;
+  }
+}
+
 module.exports = {
   getUserFromUID,
   getUserFromEmail,
@@ -181,5 +208,7 @@ module.exports = {
   getPendingEmailAddressByCode,
   removeEmailAddress,
   deleteUser,
+  getUserContext,
+  setUserContext,
 };
 

--- a/functions/util/openai.js
+++ b/functions/util/openai.js
@@ -5,6 +5,7 @@ const {zodResponseFormat} = require("openai/helpers/zod");
 const {logger} = require("firebase-functions");
 const tokenHelper = require("./tokenHelper");
 const {prompts} = require("./prompts");
+const {getUserContext} = require("./firestoreHandler");
 const {EventDataSchema, TimezoneSchema, ICSParserSchema} = require("./schemas.zod");
 const {OPENROUTER_API_KEY} = require("./config");
 const {sendEvent} = require("./analytics");
@@ -78,18 +79,29 @@ async function processEmail(email, headers, uid = null) {
   From: ${headers.from}
   ${email.text}`;
 
-  // logger.log(text);
+  let userContextInstruction = "";
+  if (uid) {
+    try {
+      const userContext = await getUserContext(uid);
+      if (userContext && userContext.trim()) {
+        userContextInstruction = `\n\nUser context (use this to decide which events are relevant and how to interpret the email):\n${userContext.trim()}`;
+      }
+    } catch (error) {
+      logger.warn(`Unable to load user context for uid ${uid}:`, error);
+    }
+  }
+
   const eventMessages = [
     {
       role: "system",
-      content: prompts.getEventData,
+      content: prompts.getEventData + userContextInstruction,
     },
     {role: "user", content: text},
   ];
   const timezoneMessages = [
     {
       role: "system",
-      content: prompts.getEventTimezone,
+      content: prompts.getEventTimezone + userContextInstruction,
     },
     {role: "user", content: text},
   ];


### PR DESCRIPTION
## Summary
This PR adds a per-user context string that can be set via email and used when parsing incoming emails into calendar events.

## Changes
- **Firestore**
  - Add `getUserContext(uid)` and `setUserContext(uid, context)` helpers on the `Users` collection.
  - Store `userContext` as a string field on `Users/{uid}`.

- **Email flow**
  - Extend `understandSubject` to handle subjects starting with `context` as a new `setContext` action.
  - Add `setUserContextFromEmail(email, sender, uid)` that:
    - Reads the previous `userContext`.
    - Replaces it with the email body.
    - Replies with a threaded email showing old vs new context.
    - Emits a `userContextUpdated` analytics event.

- **AI integration**
  - In `processEmail`, when a `uid` is available:
    - Load `userContext` from Firestore.
    - Append a short `User context` section to the system prompts for both event extraction and timezone selection.
    - If context is empty or loading fails, default back to the existing prompts.

## Behavior
- A signed-up, verified user can send an email with subject starting with `context` and the body will become their stored context (e.g. grade/school info for a child).
- All subsequent `fwd` event emails for that user will be interpreted by the AI with this context included, which can be used to filter or interpret which events are relevant.

## Notes
- No breaking changes to existing add/remove/fwd flows.
- Firestore schema is backward compatible: `userContext` is an optional field on the `Users` document.